### PR TITLE
Return urlkey from ws:createClient command

### DIFF
--- a/app/Console/Commands/CreateClient.php
+++ b/app/Console/Commands/CreateClient.php
@@ -43,13 +43,16 @@ class CreateClient extends Command
 
             return 1;
         }
+
         $secret = Str::random(60);
-        Client::factory()->create([
+        $client = Client::factory()->create([
             'name' => $name,
             'secret' => hash('sha256', $secret),
         ]);
+
         $this->info("Created Client $name");
         $this->info("Authorization Token: $secret");
+        $this->info("URL Key: {$client->urlkey}");
 
         return 0;
     }


### PR DESCRIPTION
### Summary

Neede to return the urlkey when creating clients so we can add this to the frontend secrets

### Development checklist

-   [ ] Changes have been made to the API?
    -   [ ] If so, the OpenAPI specification has been updated
-   [ ] Database migrations have been added?
    -   [ ] If so, the MySQL Workbench ERD has been updated
-   [x] The code has been linted `./compose style --fix`

### Release checklist

NA

### Notes

NA
